### PR TITLE
Strip ponctuation

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
-(defproject clojure-slugifier "0.1"
+(defproject clojure-slugifier "0.2.0"
   :description "slugifies strings"
   :url "https://github.com/donbonifacio/clojure-slugifier"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.6.0"]])
+  :dependencies [[org.clojure/clojure "1.7.0"]])

--- a/src/clojure_slugifier/core.clj
+++ b/src/clojure_slugifier/core.clj
@@ -1,13 +1,5 @@
 (ns clojure-slugifier.core)
 
-(defn- spaces-for-dashes
-  [raw]
-  (clojure.string/replace raw " " "-"))
-
-(defn- lowercase
-  [raw]
-  (clojure.string/lower-case raw))
-
 (defn- decompose
   [raw]
   (let [normalized (java.text.Normalizer/normalize raw java.text.Normalizer$Form/NFKD)]
@@ -17,7 +9,8 @@
   "Slugifies a given string"
   [raw]
   (-> raw
-      (lowercase)
-      (decompose)
-      (spaces-for-dashes)))
+      clojure.string/lower-case
+      decompose
+      (clojure.string/replace #"\.|,|;|:|'|\"" "")
+      (clojure.string/replace " " "-")))
 

--- a/test/clojure_slugifier/core_test.clj
+++ b/test/clojure_slugifier/core_test.clj
@@ -9,6 +9,9 @@
   (testing "dashes for spaces"
     (is (= "pedro-santos" (slugify "pedro santos"))))
 
+  (testing "strip quotes and ponctuation"
+    (is (= "pedro-santos" (slugify "pe;d:ro s.a,n\"to's"))))
+
   (testing "lower cases"
     (is (= "pedro-santos" (slugify "Pedro Santos")))))
 


### PR DESCRIPTION
Consider pontuaction characters and remove them.

``` clojure
(is (= "pedro-santos" (slugify "pe;d:ro s.a,n\"to's"))
```

Closes #3
