### PR TITLE
Excluding clojure.core/replace to suppress warning

### DIFF
--- a/src/clojure_slugifier/core.clj
+++ b/src/clojure_slugifier/core.clj
@@ -1,4 +1,5 @@
 (ns clojure-slugifier.core
+  (:refer-clojure :exclude [replace])
   (use [clojure.string :only (split trim replace lower-case join)]))
 
 (defn- decompose


### PR DESCRIPTION
Hi, this little patch removes this warning when loading the library in Clojure 1.8+:

```
WARNING: replace already refers to: #'clojure.core/replace in namespace: clojure-slugifier.core, being replaced by: #'clojure.string/replace
```
