### PR TITLE
Updating ns form for compatibility with clojure 1.9

### DIFF
--- a/src/clojure_slugifier/core.clj
+++ b/src/clojure_slugifier/core.clj
@@ -1,6 +1,6 @@
 (ns clojure-slugifier.core
   (:refer-clojure :exclude [replace])
-  (use [clojure.string :only (split trim replace lower-case join)]))
+  (:require [clojure.string :refer [split trim replace lower-case join]]))
 
 (defn- decompose
   [raw]


### PR DESCRIPTION
Hey, another little update to the ns form here. Without it, importing the library under clojure-1.9alpha11 fails on a spec violation about the `(use)` form:

```
% lein test
Exception in thread "main" java.lang.IllegalArgumentException: Call to clojure.core/ns did not conform to spec:
In: [2 0] val: use fails spec: :clojure.core.specs/ns-refer-clojure at: [:args :clauses :refer-clojure :clause] predicate: #{:refer-clojure}
In: [2 0] val: use fails spec: :clojure.core.specs/ns-require at: [:args :clauses :require :clause] predicate: #{:require}
In: [2 0] val: use fails spec: :clojure.core.specs/ns-import at: [:args :clauses :import :clause] predicate: #{:import}
In: [2 0] val: use fails spec: :clojure.core.specs/ns-use at: [:args :clauses :use :clause] predicate: #{:use}
In: [2 0] val: use fails spec: :clojure.core.specs/ns-refer at: [:args :clauses :refer :clause] predicate: #{:refer}
In: [2 0] val: use fails spec: :clojure.core.specs/ns-load at: [:args :clauses :load :clause] predicate: #{:load}
In: [2 0] val: use fails spec: :clojure.core.specs/ns-gen-class at: [:args :clauses :gen-class :clause] predicate: #{:gen-class}
:clojure.spec/args  (clojure-slugifier.core (:refer-clojure :exclude [replace]) (use [clojure.string :only (split trim replace lower-case join)]))
, compiling:(clojure_slugifier/core.clj:1:1)
    at clojure.lang.Compiler.macroexpand1(Compiler.java:6795)
    [...]
```
